### PR TITLE
At first send open the connection if not already opened.

### DIFF
--- a/aiologstash/tcp_handler.py
+++ b/aiologstash/tcp_handler.py
@@ -29,6 +29,10 @@ class TCPLogstashHandler(BaseLogstashHandler):
             **self._kwargs)
 
     async def _send(self, data):
+        if self._writer is None:
+            # Perform the connect at first send if not already connected.
+            # This allows the full initialisation to be done before the loop is started
+            await self._connect()
         self._writer.write(data)
         await self._writer.drain()
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+from aiologstash import __version__
+import os
+
+installs = []
+if os.name == 'nt':
+    installs+=['pywin32']
+
+setup(
+    name='aiologstash',
+    version=__version__,
+    packages=find_packages(exclude=[
+        'test',
+    ]),
+    install_requires=installs+[
+        'flit==1.3',
+        'async-timeout==3.0.1'
+    ],
+    extras_require={
+        'testing': [
+        ],
+    },
+)


### PR DESCRIPTION
This makes it much easier to instantiate the TCPLogstashHandler using the logging.config and have it immediately ready for use

<!-- Thank you for your contribution! -->

## What do these changes do?

This allows to create the handler using the factory method of logging.config.dictConfig and have the logger directly available afterwards.

## Are there changes in behavior for the user?

No

## Related issue number

Not to my knowledge. 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
